### PR TITLE
fix: token request needs no auth

### DIFF
--- a/src/un1qnx/base.py
+++ b/src/un1qnx/base.py
@@ -50,19 +50,14 @@ class API(
         if self.token: return self.token
 
         url = self.auth_url + "connect/token"
-        print(url)
         params = dict(
             client_id = self.client_id,
             client_secret = self.client_secret,
             grant_type = self.grant_type
         )
-        print(params)
-        contents = self.post(url, params = params)
-        print(contents)
+        contents = self.post(url, params = params, auth = False)
 
         self.token = contents.get("access_token", None)
-
-        raise Exception("TODO")
         return self.token
 
     def auth_callback(self, params, headers):

--- a/src/un1qnx/base.py
+++ b/src/un1qnx/base.py
@@ -24,8 +24,8 @@ class API(
         appier.API.__init__(self, *args, **kwargs)
         self.base_url = appier.conf("UN1QNX_BASE_URL", UN1QNX_BASE_URL)
         self.auth_url = appier.conf("UN1QNX_AUTH_URL", UN1QNX_AUTH_URL)
-        self.base_url = kwargs.get("base_url", self.base_url)
-        self.auth_url = kwargs.get("auth_url", self.auth_url)
+        self.base_url = kwargs.get("base_url", None) or self.base_url
+        self.auth_url = kwargs.get("auth_url", None) or self.auth_url
         self.token = kwargs.get("token", None)
         self.client_id = kwargs.get("client_id", None)
         self.client_secret = kwargs.get("client_secret", None)

--- a/src/un1qnx/base.py
+++ b/src/un1qnx/base.py
@@ -6,11 +6,11 @@ import appier
 from . import tag
 from . import product
 
-UN1QNX_BASE_URL = "http://un1qone-backend-test.azurewebsites.net/api/v2/"
+UN1QNX_BASE_URL = "https://un1qone-backend-test.azurewebsites.net/api/v2/"
 """ The default base URL to be used when no other
 base URL value is provided to the constructor """
 
-UN1QNX_AUTH_URL = "http://un1qone-identity-server-test.azurewebsites.net/"
+UN1QNX_AUTH_URL = "https://un1qone-identity-server-test.azurewebsites.net/"
 """ The default auth URL to be used when no other
 auth URL value is provided to the constructor """
 

--- a/src/un1qnx/base.py
+++ b/src/un1qnx/base.py
@@ -24,12 +24,12 @@ class API(
         appier.API.__init__(self, *args, **kwargs)
         self.base_url = appier.conf("UN1QNX_BASE_URL", UN1QNX_BASE_URL)
         self.auth_url = appier.conf("UN1QNX_AUTH_URL", UN1QNX_AUTH_URL)
-        self.base_url = kwargs.get("base_url", None) or self.base_url
-        self.auth_url = kwargs.get("auth_url", None) or self.auth_url
+        self.base_url = kwargs.get("base_url", self.base_url)
+        self.auth_url = kwargs.get("auth_url", self.auth_url)
         self.token = kwargs.get("token", None)
         self.client_id = kwargs.get("client_id", None)
         self.client_secret = kwargs.get("client_secret", None)
-        self.grant_type = kwargs.get("grant_type", None) or "client_credentials"
+        self.grant_type = kwargs.get("grant_type", "client_credentials")
 
     def build(
         self,

--- a/src/un1qnx/base.py
+++ b/src/un1qnx/base.py
@@ -29,7 +29,7 @@ class API(
         self.token = kwargs.get("token", None)
         self.client_id = kwargs.get("client_id", None)
         self.client_secret = kwargs.get("client_secret", None)
-        self.grant_type = kwargs.get("grant_type", "client_credentials")
+        self.grant_type = kwargs.get("grant_type", None) or "client_credentials"
 
     def build(
         self,
@@ -50,14 +50,19 @@ class API(
         if self.token: return self.token
 
         url = self.auth_url + "connect/token"
+        print(url)
         params = dict(
             client_id = self.client_id,
             client_secret = self.client_secret,
             grant_type = self.grant_type
         )
+        print(params)
         contents = self.post(url, params = params)
+        print(contents)
 
         self.token = contents.get("access_token", None)
+
+        raise Exception("TODO")
         return self.token
 
     def auth_callback(self, params, headers):

--- a/src/un1qnx/product.py
+++ b/src/un1qnx/product.py
@@ -9,6 +9,6 @@ class ProductAPI(object):
         return contents
 
     def get_product(self, id):
-        url = self.base_url + "products/%d" % id
+        url = self.base_url + "products/%s" % id
         contents = self.get(url)
         return contents

--- a/src/un1qnx/tag.py
+++ b/src/un1qnx/tag.py
@@ -9,7 +9,7 @@ class TagAPI(object):
         return contents
 
     def get_tag(self, id):
-        url = self.base_url + "tags/%d" % id
+        url = self.base_url + "tags/%s" % id
         contents = self.get(url)
         return contents
 
@@ -29,7 +29,7 @@ class TagAPI(object):
         return self.update_tag_state(id, "expired")
 
     def update_tag_state(self, id, state):
-        url = self.base_url + "tags/%d/partial" % id
+        url = self.base_url + "tags/%s/partial" % id
         data_j = dict(
             state = state
         )


### PR DESCRIPTION
Also changed the defaulting logic. The previous does not work if the kwargs have that key but the value is None. Initializations like [this one](https://github.com/ripe-tech/ripe-core/blob/master/src/ripe_core/models/mixins/pusherc.py#L31) would not work.