### PR TITLE
feat: create product (100% coverage)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,3 +14,10 @@ jobs:
       - run: pip install -r requirements.txt
         if: matrix.python-version != '2.7'
       - run: python setup.py test
+      - run: |
+          pip install coveralls
+          coverage run --source=un1qnx setup.py test
+          coveralls
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ session.shelve*
 
 /dist
 /build
-/src/un1qnx-api.egg-info
+/src/un1qnx_api.egg-info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Create, update and delete methods for product API - [ripe-robin-revamp/#363](https://github.com/ripe-tech/ripe-robin-revamp/issues/363)
 
 ### Changed
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setuptools.setup(
     packages = [
         "un1qnx"
     ],
+    test_suite = "un1qnx.test",
     package_dir = {
         "" : os.path.normpath("src")
     },

--- a/src/un1qnx/product.py
+++ b/src/un1qnx/product.py
@@ -8,7 +8,22 @@ class ProductAPI(object):
         contents = self.get(url, **kwargs)
         return contents
 
+    def create_product(self, product):
+        url = self.base_url + "products"
+        contents = self.post(url, data_j=product)
+        return contents
+
     def get_product(self, id):
         url = self.base_url + "products/%s" % id
         contents = self.get(url)
+        return contents
+
+    def update_product(self, id, product):
+        url = self.base_url + "products/%s" % id
+        contents = self.patch(url, data_j=product)
+        return contents
+
+    def delete_product(self, id):
+        url = self.base_url + "products/%s" % id
+        contents = self.delete(url)
         return contents

--- a/src/un1qnx/test/__init__.py
+++ b/src/un1qnx/test/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-

--- a/src/un1qnx/test/base.py
+++ b/src/un1qnx/test/base.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-import logging
 import unittest
 
 import appier

--- a/src/un1qnx/test/base.py
+++ b/src/un1qnx/test/base.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import logging
+import unittest
+
+import appier
+
+import un1qnx
+
+class APITest(unittest.TestCase):
+
+    def setUp(self):
+        self.base_url = appier.conf("TEST_BASE_URL", "https://un1qone-backend-test.azurewebsites.net/api/v2/")
+        self.auth_url = appier.conf("TEST_AUTH_URL", "https://un1qone-identity-server-test.azurewebsites.net/")
+        self.client_id = appier.conf("TEST_CLIENT_ID", None)
+        self.client_secret = appier.conf("TEST_CLIENT_SECRET", None)
+        self.grant_type = appier.conf("TEST_GRANT_TYPE", "client_credentials")
+
+        if not self.client_id:
+            if not hasattr(self, "skipTest"): return
+            self.skipTest("TEST_CLIENT_ID not defined")
+
+        if not self.client_secret:
+            if not hasattr(self, "skipTest"): return
+            self.skipTest("TEST_CLIENT_SECRET not defined")
+
+        self.api = un1qnx.API(
+            base_url = self.base_url,
+            auth_url = self.auth_url,
+            client_id = self.client_id,
+            client_secret = self.client_secret,
+            grant_type = self.grant_type
+        )
+
+    def tearDown(self):
+        self.api = None
+
+    def test_init(self):
+        self.assertEqual(self.api.base_url, "https://un1qone-backend-test.azurewebsites.net/api/v2/")
+        self.assertEqual(self.api.auth_url, "https://un1qone-identity-server-test.azurewebsites.net/")
+        self.assertEqual(self.api.token, None)
+        self.assertEqual(self.api.client_id, self.client_id)
+        self.assertEqual(self.api.client_secret, self.client_secret)
+        self.assertEqual(self.api.grant_type, self.grant_type)
+
+    def test_build(self):
+        headers = dict()
+        self.api.build("GET", "", headers = headers, kwargs = dict(auth = False))
+        self.assertEqual(headers, dict())
+
+        self.api.build("GET", "", headers = headers, kwargs = dict())
+        self.assertEqual(headers, {"Authorization": "Bearer %s" % self.api.token})
+
+    def test_get_token(self):
+        self.assertEqual(self.api.token, None)
+
+        first_token = self.api.get_token()
+        self.assertEqual(self.api.token, first_token)
+
+        second_token = self.api.get_token()
+        self.assertEqual(self.api.token, first_token)
+        self.assertEqual(first_token, second_token)
+
+    def test_auth_callback(self):
+        self.api.token = "token"
+        self.assertEqual(self.api.token, "token")
+
+        headers = dict()
+        self.api.auth_callback(dict(), headers)
+        self.assertEqual(headers, {"Authorization": "Bearer %s" % self.api.token})
+
+    def test_auth_header(self):
+        self.api.token = "token"
+        self.assertEqual(self.api.token, "token")
+
+        header = self.api.auth_header()
+        self.assertEqual(header, "Bearer token")

--- a/src/un1qnx/test/product.py
+++ b/src/un1qnx/test/product.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+import appier
+
+import un1qnx
+
+class ProductAPITest(unittest.TestCase):
+
+    def setUp(self):
+        self.base_url = appier.conf("TEST_BASE_URL", "https://un1qone-backend-test.azurewebsites.net/api/v2/")
+        self.auth_url = appier.conf("TEST_AUTH_URL", "https://un1qone-identity-server-test.azurewebsites.net/")
+        self.client_id = appier.conf("TEST_CLIENT_ID", None)
+        self.client_secret = appier.conf("TEST_CLIENT_SECRET", None)
+        self.grant_type = appier.conf("TEST_GRANT_TYPE", "client_credentials")
+
+        if not self.client_id:
+            if not hasattr(self, "skipTest"): return
+            self.skipTest("TEST_CLIENT_ID not defined")
+
+        if not self.client_secret:
+            if not hasattr(self, "skipTest"): return
+            self.skipTest("TEST_CLIENT_SECRET not defined")
+
+        self.api = un1qnx.API(
+            base_url = self.base_url,
+            auth_url = self.auth_url,
+            client_id = self.client_id,
+            client_secret = self.client_secret,
+            grant_type = self.grant_type
+        )
+
+    def tearDown(self):
+        self.api = None
+
+    def test_list_products(self):
+        products = self.api.list_products()
+        self.assertEqual("link" in products, True)
+        self.assertEqual("total" in products, True)
+        self.assertEqual("items" in products, True)

--- a/src/un1qnx/test/product.py
+++ b/src/un1qnx/test/product.py
@@ -40,3 +40,82 @@ class ProductAPITest(unittest.TestCase):
         self.assertEqual("link" in products, True)
         self.assertEqual("total" in products, True)
         self.assertEqual("items" in products, True)
+
+    def test_create_product(self):
+        try:
+            product = self.api.create_product(dict(
+                tenantId = 3,
+                brand = "dummy",
+                name = "product",
+                description = "a test product"
+            ))
+            self.assertEqual(product["tenantId"], 3)
+            self.assertEqual(product["brand"], "dummy")
+            self.assertEqual(product["name"], "product")
+            self.assertEqual(product["description"], "a test product")
+        finally:
+            self.api.delete_product(product["id"])
+
+    def test_get_product(self):
+        try:
+            first_product = self.api.create_product(dict(
+                tenantId = 3,
+                brand = "dummy",
+                name = "product",
+                description = "a test product"
+            ))
+            second_product = self.api.get_product(first_product["id"])
+            self.assertEqual(first_product["id"], second_product["id"])
+            self.assertEqual(first_product["tenantId"], 3)
+            self.assertEqual(first_product["brand"], "dummy")
+            self.assertEqual(first_product["name"], "product")
+            self.assertEqual(first_product["description"], "a test product")
+            self.assertEqual(second_product["tenantId"], 3)
+            self.assertEqual(second_product["brand"], "dummy")
+            self.assertEqual(second_product["name"], "product")
+            self.assertEqual(second_product["description"], "a test product")
+        finally:
+            self.api.delete_product(first_product["id"])
+
+    def test_update_product(self):
+        try:
+            first_product = self.api.create_product(dict(
+                tenantId = 3,
+                brand = "dummy",
+                name = "product",
+                description = "a test product"
+            ))
+            self.api.update_product(
+                first_product["id"],
+                dict(
+                    name = "updated product",
+                    description = "an updated product"
+                )    
+            )
+            second_product = self.api.get_product(first_product["id"])
+            self.assertEqual(first_product["id"], second_product["id"])
+            self.assertEqual(first_product["tenantId"], 3)
+            self.assertEqual(first_product["brand"], "dummy")
+            self.assertEqual(first_product["name"], "product")
+            self.assertEqual(first_product["description"], "a test product")
+            self.assertEqual(second_product["tenantId"], 3)
+            self.assertEqual(second_product["brand"], "dummy")
+            self.assertEqual(second_product["name"], "updated product")
+            self.assertEqual(second_product["description"], "an updated product")
+        finally:
+            self.api.delete_product(first_product["id"])
+
+    def test_get_product(self):
+        try:
+            product = self.api.create_product(dict(
+                tenantId = 3,
+                brand = "dummy",
+                name = "product",
+                description = "a test product"
+            ))
+            product = self.api.get_product(product["id"])
+            
+            self.api.delete_product(product["id"])
+            self.assertRaises(appier.HTTPError, lambda: self.api.get_product(product["id"]))
+        except:
+            self.api.delete_product(product["id"])

--- a/src/un1qnx/test/tag.py
+++ b/src/un1qnx/test/tag.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+import appier
+
+import un1qnx
+
+class TagAPITest(unittest.TestCase):
+
+    def setUp(self):
+        self.base_url = appier.conf("TEST_BASE_URL", "https://un1qone-backend-test.azurewebsites.net/api/v2/")
+        self.auth_url = appier.conf("TEST_AUTH_URL", "https://un1qone-identity-server-test.azurewebsites.net/")
+        self.client_id = appier.conf("TEST_CLIENT_ID", None)
+        self.client_secret = appier.conf("TEST_CLIENT_SECRET", None)
+        self.grant_type = appier.conf("TEST_GRANT_TYPE", "client_credentials")
+
+        if not self.client_id:
+            if not hasattr(self, "skipTest"): return
+            self.skipTest("TEST_CLIENT_ID not defined")
+
+        if not self.client_secret:
+            if not hasattr(self, "skipTest"): return
+            self.skipTest("TEST_CLIENT_SECRET not defined")
+
+        self.api = un1qnx.API(
+            base_url = self.base_url,
+            auth_url = self.auth_url,
+            client_id = self.client_id,
+            client_secret = self.client_secret,
+            grant_type = self.grant_type
+        )
+
+    def tearDown(self):
+        self.api = None
+
+    def test_list_tags(self):
+        tags = self.api.list_tags()
+        self.assertEqual("link" in tags, True)
+        self.assertEqual("total" in tags, True)
+        self.assertEqual("items" in tags, True)
+
+    def test_get_tag(self):
+        first_tag = self._get_test_tag()
+        second_tag = self.api.get_tag(first_tag["id"])
+        self.assertEqual(first_tag, second_tag)
+
+    def test_create_tag(self):
+        tag = self._get_test_tag()
+        self.api.create_tag(tag["id"])
+        tag = self.api.get_tag(tag["id"])
+        self.assertEqual(tag["state"], "Created")
+
+    def test_activate_tag(self):
+        tag = self._get_test_tag()
+        self.api.activate_tag(tag["id"])
+        tag = self.api.get_tag(tag["id"])
+        self.assertEqual(tag["state"], "Active")
+
+    def test_inactivate_tag(self):
+        tag = self._get_test_tag()
+        self.api.inactivate_tag(tag["id"])
+        tag = self.api.get_tag(tag["id"])
+        self.assertEqual(tag["state"], "Inactive")
+
+    def test_disable_tag(self):
+        tag = self._get_test_tag()
+        self.api.disable_tag(tag["id"])
+        tag = self.api.get_tag(tag["id"])
+        self.assertEqual(tag["state"], "Disabled")
+
+    def test_expire_tag(self):
+        tag = self._get_test_tag()
+        self.api.expire_tag(tag["id"])
+        tag = self.api.get_tag(tag["id"])
+        self.assertEqual(tag["state"], "Expired")
+
+    def _get_test_tag(self):
+        # tags can't be created via API so we try
+        # to retrieve an existing one
+        tags = self.api.list_tags()
+        tag = tags["items"][0] if "items" in tags and len(tags["items"]) > 0 else None
+        if not tag:
+            if not hasattr(self, "skipTest"): return
+            self.skipTest("No available UN1QNX tags to test")
+        return tag

--- a/src/un1qnx/test/tag.py
+++ b/src/un1qnx/test/tag.py
@@ -76,7 +76,7 @@ class TagAPITest(unittest.TestCase):
         tag = self.api.get_tag(tag["id"])
         self.assertEqual(tag["state"], "Expired")
 
-    def create_tag_by_code(self):
+    def test_create_tag_by_code(self):
         tag = self._get_test_tag()
         self.api.create_tag_by_code(tag["barcode"])
         tag = self.api.get_tag(tag["id"])

--- a/src/un1qnx/test/tag.py
+++ b/src/un1qnx/test/tag.py
@@ -76,6 +76,48 @@ class TagAPITest(unittest.TestCase):
         tag = self.api.get_tag(tag["id"])
         self.assertEqual(tag["state"], "Expired")
 
+    def create_tag_by_code(self):
+        tag = self._get_test_tag()
+        self.api.create_tag_by_code(tag["barcode"])
+        tag = self.api.get_tag(tag["id"])
+        self.assertEqual(tag["state"], "Created")
+
+    def test_activate_tag_by_code(self):
+        tag = self._get_test_tag()
+        self.api.activate_tag_by_code(tag["barcode"])
+        tag = self.api.get_tag(tag["id"])
+        self.assertEqual(tag["state"], "Active")
+
+    def test_inactivate_tag_by_code(self):
+        tag = self._get_test_tag()
+        self.api.inactivate_tag_by_code(tag["barcode"])
+        tag = self.api.get_tag(tag["id"])
+        self.assertEqual(tag["state"], "Inactive")
+
+    def test_disable_tag_by_code(self):
+        tag = self._get_test_tag()
+        self.api.disable_tag_by_code(tag["barcode"])
+        tag = self.api.get_tag(tag["id"])
+        self.assertEqual(tag["state"], "Disabled")
+
+    def test_expire_tag_by_code(self):
+        tag = self._get_test_tag()
+        self.api.expire_tag_by_code(tag["barcode"])
+        tag = self.api.get_tag(tag["id"])
+        self.assertEqual(tag["state"], "Expired")
+
+    def test_update_tag_state(self):
+        tag = self._get_test_tag()
+        self.api.update_tag_state(tag["id"], "Expired")
+        tag = self.api.get_tag(tag["id"])
+        self.assertEqual(tag["state"], "Expired")
+
+    def test_update_tag_state_by_code(self):
+        tag = self._get_test_tag()
+        self.api.update_tag_state_by_code(tag["barcode"], "Expired")
+        tag = self.api.get_tag(tag["id"])
+        self.assertEqual(tag["state"], "Expired")
+
     def _get_test_tag(self):
         # tags can't be created via API so we try
         # to retrieve an existing one


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/363 |
| Dependencies | -- |
| Decisions | Add create, read and update methods to product API. Test coverage of 100%.  |
| Animated GIF | ![image](https://user-images.githubusercontent.com/16060539/170509643-b47a3b10-873b-4b45-9993-0c97f36ae90e.png) |

**CI passes if coveralls secrets are defined https://github.com/ripe-tech/un1qnx-api/blob/jc/feat-create-product/.github/workflows/main.yml#L22-L23**

**Tests will be skipped unless TEST_CLIENT_SECRET and TEST_CLIENT_ID are defined as env vars**