### PR TITLE
ci: omit tests from coverage report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           TEST_CLIENT_SECRET : ${{ secrets.TEST_CLIENT_SECRET }}
       - run: |
           pip install coveralls
-          coverage run --source=un1qnx setup.py test
+          coverage run --source=un1qnx --omit="*/test*" setup.py test
           coveralls
         env:
           TEST_CLIENT_ID : ${{ secrets.TEST_CLIENT_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           TEST_CLIENT_SECRET : ${{ secrets.TEST_CLIENT_SECRET }}
       - run: |
           pip install coveralls
-          coverage run --source=un1qnx --omit="*/test*" setup.py test
+          coverage run --source=un1qnx --omit="src/un1qnx/test/*" setup.py test
           coveralls
         env:
           TEST_CLIENT_ID : ${{ secrets.TEST_CLIENT_ID }}


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/363 |
| Dependencies | -- |
| Decisions | We should omit the test source code from the coverage itself. |
| Animated GIF | ![image](https://user-images.githubusercontent.com/16060539/170731556-c9e3f2b9-0182-4b8d-b720-7f35e4a22aa6.png)|
